### PR TITLE
feat: reduce job count by evaluating nar hash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,19 +281,15 @@ jobs:
           if [[ "${{ inputs.eval_target }}" != '' ]]; then
             echo "Evaluating x86_64-linux outputs"
             nix run github:nix-community/nix-eval-jobs -- --workers $(nproc) --max-memory-size $(free -m  | grep ^Mem | tr -s ' ' | cut -d ' ' -f 3) --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#"${{ inputs.eval_target }}".x86_64-linux | jq -s 'map(.top_attr = "${{ inputs.eval_top_attr }}")' >> flake_evals.json
-            echo "flake_evals.json:"
-            cat flake_evals.json | jq .
             echo "Evaluating aarch64-linux outputs"
             nix run github:nix-community/nix-eval-jobs -- --workers $(nproc) --max-memory-size $(free -m  | grep ^Mem | tr -s ' ' | cut -d ' ' -f 3) --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#"${{ inputs.eval_target }}".aarch64-linux | jq -s 'map(.top_attr = "${{ inputs.eval_top_attr }}")' >> flake_evals.json
-            echo "flake_evals.json:"
-            cat flake_evals.json | jq .
 
             jq -s 'add' flake_evals.json > evals.json
 
-            echo "evals.json:"
-            cat evals.json | jq .
-
             cat evals.json | jq '.[] | select(.isCached | not)' > to_build.json
+
+            echo "to_build.json:"
+            cat to_build.json | jq '.[] | .attr'
 
             echo "Filtering outputs with filter_builds"
             echo $flake_outputs | jq --slurpfile evals to_build.json '
@@ -308,6 +304,9 @@ jobs:
                   )
                 )
               ' > $flake_json
+
+            echo "flake_json:"
+            cat $flake_json | jq .
           fi
             jq < "$flake_json" -rc 'map(
               . as $x | (${{inputs.label_builds}}) as $l | $x + {label: $l})|"builds=\(.)"' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,7 +232,8 @@ jobs:
         id: find-builds
         run: |
           set -eo pipefail
-          flake_json="$(mktemp)"
+          touch flake.json
+          flake_json="flake.json"
           # For Nix >= 2.14 we need --all-systems
           if [[ "${{inputs.nix_version}}" =~ 2.1[456789].* ]]; then
             all_systems="--all-systems"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -300,7 +300,7 @@ jobs:
                 map(
                   select(
                     (.top_attr) as $top_attr | (.system) as $system | (.attr) as $attr | 
-                    $evals | .[] | .[] | select(
+                    $evals | .[] | select(
                       (.top_attr == $top_attr) and 
                       (.system == $system) and 
                       (.attr == $attr)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,9 +288,6 @@ jobs:
 
             cat evals.json | jq '.[] | select(.isCached | not)' > to_build.json
 
-            echo "to_build.json:"
-            cat to_build.json | jq '.[] | .attr'
-
             echo "Filtering outputs with filter_builds"
             echo $flake_outputs | jq --slurpfile evals to_build.json '
                 map(

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,7 +240,7 @@ jobs:
             all_systems=""
           fi
           nix flake show "./${{inputs.flake_directory}}" $all_systems --json > "$flake_json"
-          cat "$flake_json" | jq -rc '{
+          flake_outputs=$(cat "$flake_json" | jq -rc '{
             checks: (.checks // {}), 
             packages: (.packages // {}), 
             devShells: (.devShells // {})
@@ -260,10 +260,12 @@ jobs:
             select(
               ${{inputs.filter_builds}}
             )
-          )'
+          )')
 
+          echo "outputs.txt $LINENO"
           echo $flake_outputs | jq -r '.[] | "\(.top_attr).\(.system).\(.attr)"' > outputs.txt
 
+          echo "loop $LINENO"
           cat outputs.txt | while read line
           do
             attr=$(echo $line | cut -d '.' -f3)
@@ -277,9 +279,11 @@ jobs:
              --arg nar "$nar" \
              'map(if (.attr == $attr) and (.system == $system) and (.top_attr == $top_attr) then .nar = $nar else . end)')
 
+            touch flak_outputs.json
             echo "$flake_outputs" | jq . > flake_outputs.json  
           done
 
+          echo "collect nars $LINENO"
           nar_hashes=$(cat flake_outputs.json | jq 'map(.nar)')
 
           nars_to_build=$(curl -X 'POST' \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -279,7 +279,7 @@ jobs:
 
           touch flake_evals.json
           if [[ "${{ inputs.eval_target }}" != '' ]]; then
-            nix run github:nix-community/nix-eval-jobs -- --workers $(nproc) --max-memory-size $(free -m  | grep ^Mem | tr -s ' ' | cut -d ' ' -f 3) --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#"${{ inputs.eval_target }}" | jq -s 'map(.top_attr = "${{ inputs.eval_top_attr }}")' >> flake_evals.json
+            nix run github:nix-community/nix-eval-jobs -- --workers $(nproc) --max-memory-size $(free -m  | grep ^Mem | tr -s ' ' | cut -d ' ' -f 3) --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#"${{ inputs.eval_target }}".x86_64-linux | jq -s 'map(.top_attr = "${{ inputs.eval_top_attr }}")' >> flake_evals.json
 
             echo "flake_evals.json:"
             cat flake_evals.json | jq .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -280,14 +280,12 @@ jobs:
           touch flake_evals.json
           if [[ "${{ inputs.eval_target }}" != '' ]]; then
             nix run github:nix-community/nix-eval-jobs -- --workers $(nproc) --max-memory-size $(free -m  | grep ^Mem | tr -s ' ' | cut -d ' ' -f 3) --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#"${{ inputs.eval_target }}" | jq -s 'map(.top_attr = "${{ inputs.eval_top_attr }}")' >> flake_evals.json
-          fi
 
-          echo "flake_evals.json:"
-          cat flake_evals.json | jq .
+            echo "flake_evals.json:"
+            cat flake_evals.json | jq .
 
-          cat evals.json | jq '.[] | select(.isCached | not)' > to_build.json
+            cat flake_evals.json | jq '.[] | select(.isCached | not)' > to_build.json
 
-          if [[ "${{ inputs.eval_target }}" != '' ]]; then
             echo $flake_outputs | jq --slurpfile evals to_build.json '
               ($evals | map(.top_attr)) as $top_attrs |
               ($evals | map(.attr)) as $attrs |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,8 +281,12 @@ jobs:
           if [[ "${{ inputs.eval_target }}" != '' ]]; then
             echo "Evaluating x86_64-linux outputs"
             nix run github:nix-community/nix-eval-jobs -- --workers $(nproc) --max-memory-size $(free -m  | grep ^Mem | tr -s ' ' | cut -d ' ' -f 3) --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#"${{ inputs.eval_target }}".x86_64-linux | jq -s 'map(.top_attr = "${{ inputs.eval_top_attr }}")' >> flake_evals.json
+            echo "flake_evals.json:"
+            cat flake_evals.json | jq .
             echo "Evaluating aarch64-linux outputs"
             nix run github:nix-community/nix-eval-jobs -- --workers $(nproc) --max-memory-size $(free -m  | grep ^Mem | tr -s ' ' | cut -d ' ' -f 3) --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#"${{ inputs.eval_target }}".aarch64-linux | jq -s 'map(.top_attr = "${{ inputs.eval_top_attr }}")' >> flake_evals.json
+            echo "flake_evals.json:"
+            cat flake_evals.json | jq .
 
             cat flake_evals.json | jq 'add' > flake_evals.json
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,12 +288,12 @@ jobs:
             echo "flake_evals.json:"
             cat flake_evals.json | jq .
 
-            cat flake_evals.json | jq 'add' > flake_evals.json
+            cat flake_evals.json | jq 'add' > evals.json
 
-            echo "flake_evals.json:"
-            cat flake_evals.json | jq .
+            echo "evals.json:"
+            cat evals.json | jq .
 
-            cat flake_evals.json | jq '.[] | select(.isCached | not)' > to_build.json
+            cat evals.json | jq '.[] | select(.isCached | not)' > to_build.json
 
             echo "Filtering outputs with filter_builds"
             echo $flake_outputs | jq --slurpfile evals to_build.json '

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -290,7 +290,7 @@ jobs:
             'https://app.cachix.org/api/v1/cache/union/narinfo' \
             -H 'accept: application/json;charset=utf-8' \
             -H 'Content-Type: application/json;charset=utf-8' \
-            -d $nar_hashes)
+            -d "$nar_hashes")
 
           cat flake_outputs.json | jq --arg nars "$nars_to_build" 'map(select(.nar | inside($nars)))' > "$flake_json"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -279,8 +279,10 @@ jobs:
 
           touch flake_evals.json
           if [[ "${{ inputs.eval_target }}" != '' ]]; then
+            echo "Evaluating x86_64-linux outputs"
             nix run github:nix-community/nix-eval-jobs -- --workers $(nproc) --max-memory-size $(free -m  | grep ^Mem | tr -s ' ' | cut -d ' ' -f 3) --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#"${{ inputs.eval_target }}".x86_64-linux | jq -s 'map(.top_attr = "${{ inputs.eval_top_attr }}")' >> flake_evals.json
-            nix run github:nix-community/nix-eval-jobs --system aarch64-linux -- --workers $(nproc) --max-memory-size $(free -m  | grep ^Mem | tr -s ' ' | cut -d ' ' -f 3) --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#"${{ inputs.eval_target }}".aarch64-linux | jq -s 'map(.top_attr = "${{ inputs.eval_top_attr }}")' >> flake_evals.json
+            echo "Evaluating aarch64-linux outputs"
+            nix run github:nix-community/nix-eval-jobs -- --workers $(nproc) --max-memory-size $(free -m  | grep ^Mem | tr -s ' ' | cut -d ' ' -f 3) --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#"${{ inputs.eval_target }}".aarch64-linux | jq -s 'map(.top_attr = "${{ inputs.eval_top_attr }}")' >> flake_evals.json
 
             cat flake_evals.json | jq 'add' > flake_evals.json
 
@@ -289,6 +291,7 @@ jobs:
 
             cat flake_evals.json | jq '.[] | select(.isCached | not)' > to_build.json
 
+            echo "Filtering outputs with filter_builds"
             echo $flake_outputs | jq --slurpfile evals to_build.json '
                 map(
                   select(
@@ -301,10 +304,9 @@ jobs:
                   )
                 )
               ' > $flake_json
-          else
+          fi
             jq < "$flake_json" -rc 'map(
               . as $x | (${{inputs.label_builds}}) as $l | $x + {label: $l})|"builds=\(.)"' >> "$GITHUB_OUTPUT"
-          fi
           
   build:
     name: ${{matrix.build.label}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -263,36 +263,25 @@ jobs:
             )
           )')
 
-          echo $flake_outputs | jq -r '.[] | "\(.top_attr).\(.system).\(.attr)"' > outputs.txt
+          touch flake_evals.json
+          nix run github:nix-community/nix-eval-jobs -- --check-cache-status --flake .#packages.x86_64-linux | jq -s 'map(.top_attr = "packages")' >> flake_evals.json
+          nix run github:nix-community/nix-eval-jobs -- --check-cache-status --flake .#checks.x86_64-linux | jq -s 'map(.top_attr = "checks")' >> flake_evals.json
+          nix run github:nix-community/nix-eval-jobs -- --check-cache-status --flake .#devShells.x86_64-linux | jq -s 'map(.top_attr = "checks")' >> flake_evals.json
 
-          cat outputs.txt | while read line
-          do
-            attr=$(echo $line | cut -d '.' -f3)
-            system=$(echo $line | cut -d '.' -f2)
-            top_attr=$(echo $line | cut -d '.' -f1)
-            nar=$(nix eval --quiet --raw .#$line | cut -d '/' -f4 | cut -d '-' -f1)
-            flake_outputs=$(echo $flake_outputs | jq \
-             --arg attr "$attr" \
-             --arg system "$system" \
-             --arg top_attr "$top_attr" \
-             --arg nar "$nar" \
-             'map(if (.attr == $attr) and (.system == $system) and (.top_attr == $top_attr) then .nar = $nar else . end)')
+          jq -s 'add' flake_evals.json > evals.json
 
-            touch flak_outputs.json
-            echo "$flake_outputs" | jq . > flake_outputs.json  
+          cat evals.json | jq '.[] | select(.isCached | not)' > to_build.json
 
-          done
-
-          nar_hashes=$(cat flake_outputs.json | jq 'map(.nar)')
-
-          nars_to_build=$(curl -X 'POST' \
-            'https://app.cachix.org/api/v1/cache/union/narinfo' \
-            -H 'accept: application/json;charset=utf-8' \
-            -H 'Content-Type: application/json;charset=utf-8' \
-            -d "$nar_hashes")
-
-          cat flake_outputs.json | jq --arg nars "$nars_to_build" 'map(select(.nar | inside($nars)))' > "$flake_json"
-
+          echo $flake_outputs | jq --slurpfile evals to_build.json '
+            ($evals | map(.top_attr)) as $top_attrs |
+            ($evals | map(.attr)) as $attrs |
+            map(
+              select(
+                ([.top_attr] | inside($top_attrs)) and
+                ([.attr] | inside($attrs))
+              )
+            )' > $flake_json
+          
           jq < "$flake_json" -rc 'map(
             . as $x | (${{inputs.label_builds}}) as $l | $x + {label: $l})|"builds=\(.)"' >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,7 +240,58 @@ jobs:
             all_systems=""
           fi
           nix flake show "./${{inputs.flake_directory}}" $all_systems --json > "$flake_json"
-          jq < "$flake_json" -rc '{checks: (.checks // {}), packages: (.packages // {}), devShells: (.devShells // {})}|to_entries|map(.key as $top_attr | .value|to_entries|map(.key as $sys | .value|to_entries|map(.key as $attr | {name: "", description: "", top_attr: $top_attr, system: $sys, attr: $attr} + .value)))|flatten|map(select(${{inputs.filter_builds}}))|map(. as $x | (${{inputs.label_builds}}) as $l | $x + {label: $l})|"builds=\(.)"' >> "$GITHUB_OUTPUT"
+          cat "$flake_json" | jq -rc '{
+            checks: (.checks // {}), 
+            packages: (.packages // {}), 
+            devShells: (.devShells // {})
+          } | to_entries | map(
+            .key as $top_attr | .value | to_entries | map(
+              .key as $sys | .value | to_entries | map(
+                .key as $attr | {
+                  name: "",
+                  description: "",
+                  top_attr: $top_attr, 
+                  system: $sys, 
+                  attr: $attr
+                } + .value
+              )
+            )
+          ) | flatten | map(
+            select(
+              ${{inputs.filter_builds}}
+            )
+          )'
+
+          echo $flake_outputs | jq -r '.[] | "\(.top_attr).\(.system).\(.attr)"' > outputs.txt
+
+          cat outputs.txt | while read line
+          do
+            attr=$(echo $line | cut -d '.' -f3)
+            system=$(echo $line | cut -d '.' -f2)
+            top_attr=$(echo $line | cut -d '.' -f1)
+            nar=$(nix eval --quiet --raw .#$line | cut -d '/' -f4 | cut -d '-' -f1)
+            flake_outputs=$(echo $flake_outputs | jq \
+             --arg attr "$attr" \
+             --arg system "$system" \
+             --arg top_attr "$top_attr" \
+             --arg nar "$nar" \
+             'map(if (.attr == $attr) and (.system == $system) and (.top_attr == $top_attr) then .nar = $nar else . end)')
+
+            echo "$flake_outputs" | jq . > flake_outputs.json  
+          done
+
+          nar_hashes=$(cat flake_outputs.json | jq 'map(.nar)')
+
+          nars_to_build=$(curl -X 'POST' \
+            'https://app.cachix.org/api/v1/cache/union/narinfo' \
+            -H 'accept: application/json;charset=utf-8' \
+            -H 'Content-Type: application/json;charset=utf-8' \
+            -d $nar_hashes)
+
+          cat flake_outputs.json | jq --arg nars "$nars_to_build" 'map(select(.nar | inside($nars)))' > "$flake_json"
+
+          jq < "$flake_json" -rc 'map(
+            . as $x | (${{inputs.label_builds}}) as $l | $x + {label: $l})|"builds=\(.)"' >> "$GITHUB_OUTPUT"
 
   build:
     name: ${{matrix.build.label}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,7 +221,7 @@ on:
         default: ''
         required: false
         description: |
-          To avoid collisions with outputs that have the same `attr` but different `top_attr`, a top_atter for the eval target can be supplied here.
+          To avoid collisions with outputs that have the same `attr` but different `top_attr`, a top_attr for the eval target can be supplied here.
 
 jobs:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ on:
       filter_builds:
         type: string
         required: false
-        default: ''
+        default: '""'
         description: |
           A `jq` boolean expression that decides which builds from `flake.nix`
           to build. See the `jq` documentation for info on how to write boolean

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -264,9 +264,9 @@ jobs:
           )')
 
           touch flake_evals.json
-          nix run github:nix-community/nix-eval-jobs -- --check-cache-status --flake .#packages.x86_64-linux | jq -s 'map(.top_attr = "packages")' >> flake_evals.json
-          nix run github:nix-community/nix-eval-jobs -- --check-cache-status --flake .#checks.x86_64-linux | jq -s 'map(.top_attr = "checks")' >> flake_evals.json
-          nix run github:nix-community/nix-eval-jobs -- --check-cache-status --flake .#devShells.x86_64-linux | jq -s 'map(.top_attr = "checks")' >> flake_evals.json
+          nix run github:nix-community/nix-eval-jobs -- --workers 8 --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#packages.x86_64-linux | jq -s 'map(.top_attr = "packages")' >> flake_evals.json
+          nix run github:nix-community/nix-eval-jobs -- --workers 8 --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#checks.x86_64-linux | jq -s 'map(.top_attr = "checks")' >> flake_evals.json
+          nix run github:nix-community/nix-eval-jobs -- --workers 8 --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#devShells.x86_64-linux | jq -s 'map(.top_attr = "checks")' >> flake_evals.json
 
           jq -s 'add' flake_evals.json > evals.json
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -282,6 +282,9 @@ jobs:
 
             touch flak_outputs.json
             echo "$flake_outputs" | jq . > flake_outputs.json  
+
+            echo "Disk Usage:"
+            df -h
           done
 
           echo "collect nars $LINENO"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,6 +209,20 @@ on:
         description: |
           If remote store should be used, or instead remote builders.
 
+      eval_target:
+        type: string
+        default: ''
+        required: false
+        description: |
+          A single nix evaluation target that will be used to determine which outputs jobs should be created for. If an output is evaluated and determined to already be cached, it will not have a job created for it.
+
+      eval_top_attr:
+        type: string
+        default: ''
+        required: false
+        description: |
+          To avoid collisions with outputs that have the same `attr` but different `top_attr`, a top_atter for the eval target can be supplied here.
+
 jobs:
 
   eval-flake:
@@ -264,23 +278,26 @@ jobs:
           )')
 
           touch flake_evals.json
-          nix run github:nix-community/nix-eval-jobs -- --workers $(nproc) --max-memory-size $(free -m  | grep ^Mem | tr -s ' ' | cut -d ' ' -f 3) --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#packages.x86_64-linux | jq -s 'map(.top_attr = "packages")' >> flake_evals.json
-          nix run github:nix-community/nix-eval-jobs -- --workers $(nproc) --max-memory-size $(free -m  | grep ^Mem | tr -s ' ' | cut -d ' ' -f 3) --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#checks.x86_64-linux | jq -s 'map(.top_attr = "checks")' >> flake_evals.json
-          nix run github:nix-community/nix-eval-jobs -- --workers $(nproc) --max-memory-size $(free -m  | grep ^Mem | tr -s ' ' | cut -d ' ' -f 3) --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#devShells.x86_64-linux | jq -s 'map(.top_attr = "checks")' >> flake_evals.json
+          if [[ "${{ inputs.eval_target }}" != '' ]]
+            nix run github:nix-community/nix-eval-jobs -- --workers $(nproc) --max-memory-size $(free -m  | grep ^Mem | tr -s ' ' | cut -d ' ' -f 3) --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#"${{ inputs.eval_target }}" | jq -s 'map(.top_attr = "${{ inputs.eval_top_attr }}")' >> flake_evals.json
+          fi
 
-          jq -s 'add' flake_evals.json > evals.json
+          echo "flake_evals.json:"
+          cat flake_evals.json | jq .
 
           cat evals.json | jq '.[] | select(.isCached | not)' > to_build.json
 
-          echo $flake_outputs | jq --slurpfile evals to_build.json '
-            ($evals | map(.top_attr)) as $top_attrs |
-            ($evals | map(.attr)) as $attrs |
-            map(
-              select(
-                ([.top_attr] | inside($top_attrs)) and
-                ([.attr] | inside($attrs))
-              )
-            )' > $flake_json
+          if [[ "${{ inputs.eval_target }}" != '' ]]
+            echo $flake_outputs | jq --slurpfile evals to_build.json '
+              ($evals | map(.top_attr)) as $top_attrs |
+              ($evals | map(.attr)) as $attrs |
+              map(
+                select(
+                  ([.top_attr] | inside($top_attrs)) and
+                  ([.attr] | inside($attrs))
+                )
+              )' > $flake_json
+          fi
           
           jq < "$flake_json" -rc 'map(
             . as $x | (${{inputs.label_builds}}) as $l | $x + {label: $l})|"builds=\(.)"' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -263,10 +263,8 @@ jobs:
             )
           )')
 
-          echo "outputs.txt $LINENO"
           echo $flake_outputs | jq -r '.[] | "\(.top_attr).\(.system).\(.attr)"' > outputs.txt
 
-          echo "loop $LINENO"
           cat outputs.txt | while read line
           do
             attr=$(echo $line | cut -d '.' -f3)
@@ -283,11 +281,8 @@ jobs:
             touch flak_outputs.json
             echo "$flake_outputs" | jq . > flake_outputs.json  
 
-            echo "Disk Usage:"
-            df -h
           done
 
-          echo "collect nars $LINENO"
           nar_hashes=$(cat flake_outputs.json | jq 'map(.nar)')
 
           nars_to_build=$(curl -X 'POST' \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -280,6 +280,9 @@ jobs:
           touch flake_evals.json
           if [[ "${{ inputs.eval_target }}" != '' ]]; then
             nix run github:nix-community/nix-eval-jobs -- --workers $(nproc) --max-memory-size $(free -m  | grep ^Mem | tr -s ' ' | cut -d ' ' -f 3) --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#"${{ inputs.eval_target }}".x86_64-linux | jq -s 'map(.top_attr = "${{ inputs.eval_top_attr }}")' >> flake_evals.json
+            nix run github:nix-community/nix-eval-jobs --system aarch64-linux -- --workers $(nproc) --max-memory-size $(free -m  | grep ^Mem | tr -s ' ' | cut -d ' ' -f 3) --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#"${{ inputs.eval_target }}".aarch64-linux | jq -s 'map(.top_attr = "${{ inputs.eval_top_attr }}")' >> flake_evals.json
+
+            cat flake_evals.json | jq 'add' > flake_evals.json
 
             echo "flake_evals.json:"
             cat flake_evals.json | jq .
@@ -287,19 +290,22 @@ jobs:
             cat flake_evals.json | jq '.[] | select(.isCached | not)' > to_build.json
 
             echo $flake_outputs | jq --slurpfile evals to_build.json '
-              ($evals | map(.top_attr)) as $top_attrs |
-              ($evals | map(.attr)) as $attrs |
-              map(
-                select(
-                  ([.top_attr] | inside($top_attrs)) and
-                  ([.attr] | inside($attrs))
+                map(
+                  select(
+                    (.top_attr) as $top_attr | (.system) as $system | (.attr) as $attr | 
+                    $evals | .[] | .[] | select(
+                      (.top_attr == $top_attr) and 
+                      (.system == $system) and 
+                      (.attr == $attr)
+                    ) != null
+                  )
                 )
-              )' > $flake_json
+              ' > $flake_json
+          else
+            jq < "$flake_json" -rc 'map(
+              . as $x | (${{inputs.label_builds}}) as $l | $x + {label: $l})|"builds=\(.)"' >> "$GITHUB_OUTPUT"
           fi
           
-          jq < "$flake_json" -rc 'map(
-            . as $x | (${{inputs.label_builds}}) as $l | $x + {label: $l})|"builds=\(.)"' >> "$GITHUB_OUTPUT"
-
   build:
     name: ${{matrix.build.label}}
     needs: eval-flake

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,7 +278,7 @@ jobs:
           )')
 
           touch flake_evals.json
-          if [[ "${{ inputs.eval_target }}" != '' ]]
+          if [[ "${{ inputs.eval_target }}" != '' ]]; then
             nix run github:nix-community/nix-eval-jobs -- --workers $(nproc) --max-memory-size $(free -m  | grep ^Mem | tr -s ' ' | cut -d ' ' -f 3) --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#"${{ inputs.eval_target }}" | jq -s 'map(.top_attr = "${{ inputs.eval_top_attr }}")' >> flake_evals.json
           fi
 
@@ -287,7 +287,7 @@ jobs:
 
           cat evals.json | jq '.[] | select(.isCached | not)' > to_build.json
 
-          if [[ "${{ inputs.eval_target }}" != '' ]]
+          if [[ "${{ inputs.eval_target }}" != '' ]]; then
             echo $flake_outputs | jq --slurpfile evals to_build.json '
               ($evals | map(.top_attr)) as $top_attrs |
               ($evals | map(.attr)) as $attrs |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,7 +220,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: nixbuild/nix-quick-install-action@v26
         with:
-          nix_on_tmpfs: true
+          nix_on_tmpfs: false
           nix_conf: |
             experimental-features = nix-command flakes
             access-tokens = ${{ secrets.access-tokens }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -264,9 +264,9 @@ jobs:
           )')
 
           touch flake_evals.json
-          nix run github:nix-community/nix-eval-jobs -- --workers 8 --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#packages.x86_64-linux | jq -s 'map(.top_attr = "packages")' >> flake_evals.json
-          nix run github:nix-community/nix-eval-jobs -- --workers 8 --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#checks.x86_64-linux | jq -s 'map(.top_attr = "checks")' >> flake_evals.json
-          nix run github:nix-community/nix-eval-jobs -- --workers 8 --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#devShells.x86_64-linux | jq -s 'map(.top_attr = "checks")' >> flake_evals.json
+          nix run github:nix-community/nix-eval-jobs -- --workers $(nproc) --max-memory-size $(free -m  | grep ^Mem | tr -s ' ' | cut -d ' ' -f 3) --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#packages.x86_64-linux | jq -s 'map(.top_attr = "packages")' >> flake_evals.json
+          nix run github:nix-community/nix-eval-jobs -- --workers $(nproc) --max-memory-size $(free -m  | grep ^Mem | tr -s ' ' | cut -d ' ' -f 3) --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#checks.x86_64-linux | jq -s 'map(.top_attr = "checks")' >> flake_evals.json
+          nix run github:nix-community/nix-eval-jobs -- --workers $(nproc) --max-memory-size $(free -m  | grep ^Mem | tr -s ' ' | cut -d ' ' -f 3) --gc-roots-dir $(pwd)/gcroots --check-cache-status --flake .#devShells.x86_64-linux | jq -s 'map(.top_attr = "checks")' >> flake_evals.json
 
           jq -s 'add' flake_evals.json > evals.json
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ on:
       filter_builds:
         type: string
         required: false
-        default: '.top_attr == "checks"'
+        default: ''
         description: |
           A `jq` boolean expression that decides which builds from `flake.nix`
           to build. See the `jq` documentation for info on how to write boolean

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,7 +288,7 @@ jobs:
             echo "flake_evals.json:"
             cat flake_evals.json | jq .
 
-            cat flake_evals.json | jq 'add' > evals.json
+            jq -s 'add' flake_evals.json > evals.json
 
             echo "evals.json:"
             cat evals.json | jq .


### PR DESCRIPTION
- adds `eval_target` and `eval_top_attr` which are used to create an evaluation that is compared to the result of `filter_builds` to determine if jobs should be queued or not. Jobs who's outputs are already cached will not not be built