### PR TITLE
fix: filter_builds not being applied and summaries on zero job runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,7 +313,7 @@ jobs:
     name: ${{matrix.build.label}}
     needs: eval-flake
     runs-on: ubuntu-latest
-    if: ${{ needs.eval-flake.outputs.builds != "" }}
+    if: ${{ needs.eval-flake.outputs.builds != '' }}
     strategy:
       fail-fast: ${{ inputs.fail_fast }}
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,7 +313,7 @@ jobs:
     name: ${{matrix.build.label}}
     needs: eval-flake
     runs-on: ubuntu-latest
-    if: ${{ needs.eval-flake.outputs.builds != '' }}
+    if: ${{ needs.eval-flake.outputs.builds != '[]' }}
     strategy:
       fail-fast: ${{ inputs.fail_fast }}
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,6 +313,8 @@ jobs:
     name: ${{matrix.build.label}}
     needs: eval-flake
     runs-on: ubuntu-latest
+    if:
+      ${{ needs.eval-flake.outputs.builds != "" }}
     strategy:
       fail-fast: ${{ inputs.fail_fast }}
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -301,10 +301,10 @@ jobs:
                   )
                 )
               ' > $flake_json
-
-            echo "flake_json:"
-            cat $flake_json | jq .
           fi
+
+            echo "Jobs to build:"
+            cat $flake_json | jq .
             jq < "$flake_json" -rc 'map(
               . as $x | (${{inputs.label_builds}}) as $l | $x + {label: $l})|"builds=\(.)"' >> "$GITHUB_OUTPUT"
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -276,6 +276,7 @@ jobs:
               ${{inputs.filter_builds}}
             )
           )')
+          echo $flake_outputs | jq . > $flake_json
 
           touch flake_evals.json
           if [[ "${{ inputs.eval_target }}" != '' ]]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,8 +313,7 @@ jobs:
     name: ${{matrix.build.label}}
     needs: eval-flake
     runs-on: ubuntu-latest
-    if:
-      ${{ needs.eval-flake.outputs.builds != "" }}
+    if: ${{ needs.eval-flake.outputs.builds != "" }}
     strategy:
       fail-fast: ${{ inputs.fail_fast }}
       matrix:


### PR DESCRIPTION
- Fixes issue with nightly builds where filter_builds wasn't being applied without eval_target being supplied.
  - Fix demonstrated [here](https://github.com/unionlabs/union/actions/runs/7786460547/job/21231418919)
- Fixes issue where build summaries triggered an error if there were no jobs queued
  - Fix demonstrated [here](https://github.com/unionlabs/union/actions/runs/7788142685)