### PR TITLE
feat: use beefy-sausage runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,7 +270,10 @@ jobs:
           )')
           echo $flake_outputs | jq . > $flake_json
 
+
           touch flake_evals.json
+          echo "flake_evals.json"
+          jq . flake_evals.json
           if [[ "${{ inputs.eval_target }}" != '' ]]; then
             echo "Evaluating x86_64-linux outputs"
             nix eval --json .#"${{ inputs.eval_target }}".x86_64-linux | jq '
@@ -303,6 +306,9 @@ jobs:
               -d "$(cat evals.json | jq 'map(.nar)')" > nars_to_build.json
             cat evals.json | jq --slurpfile nars_to_build nars_to_build.json '
               map(select([.nar] | inside($nars_to_build | .[])))' > to_build.json
+
+            echo "to_build.json"
+            jq . to_build.json
 
             echo "Filtering outputs with filter_builds"
             echo $flake_outputs | jq --slurpfile evals to_build.json '

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -231,6 +231,12 @@ jobs:
     outputs:
       builds: ${{ steps.find-builds.outputs.builds }}
     steps:
+      - name: 'Clean build folder'
+        run: |
+          ls -la ./
+          rm -rf ./* || true
+          rm -rf ./.??* || true
+          ls -la ./
       - uses: actions/checkout@v4
       - name: Pre-evaluation script
         run: ${{inputs.pre_evaluation_script}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,12 +278,11 @@ jobs:
           echo $flake_outputs | jq . > $flake_json
 
 
-          touch flake_evals.json
-          echo "flake_evals.json"
-          jq . flake_evals.json
+          touch x86_64-evals.json
+          touch aarch64-evals.json
           if [[ "${{ inputs.eval_target }}" != '' ]]; then
             echo "Evaluating x86_64-linux outputs"
-            time nix eval --json .#"${{ inputs.eval_target }}".x86_64-linux | jq '
+            (nix eval --json .#"${{ inputs.eval_target }}".x86_64-linux | jq '
               to_entries | map(
                 {
                   top_attr: "${{ inputs.eval_top_attr}}",
@@ -292,8 +291,8 @@ jobs:
                   nar: (.value | split("/")[3] | split("-")[0])
                 }
               )
-            ' >> flake_evals.json
-            time nix eval --json .#"${{ inputs.eval_target }}".aarch64-linux | jq '
+            ' >> x86_64-evals.json) &
+            (nix eval --json .#"${{ inputs.eval_target }}".aarch64-linux | jq '
               to_entries | map(
                 {
                   top_attr: "${{ inputs.eval_top_attr}}",
@@ -302,9 +301,10 @@ jobs:
                   nar: (.value | split("/")[3] | split("-")[0])
                 }
               )
-            ' >> flake_evals.json
+            ' >> aarch64-evals.json) &
+            wait
 
-            jq -s 'add' flake_evals.json > evals.json
+            jq -s 'add' x86_64-evals.json aarch64-evals.json > evals.json
 
             curl -X 'POST' \
               'https://app.cachix.org/api/v1/cache/union/narinfo' \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,7 +227,7 @@ jobs:
 
   eval-flake:
     name: "Evaluate flake"
-    runs-on: beefy-sausage-16-32-hil-1
+    runs-on: beefy-sausage-16-32-hel1-1
     outputs:
       builds: ${{ steps.find-builds.outputs.builds }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,7 +237,10 @@ jobs:
           rm -rf ./* || true
           rm -rf ./.??* || true
           ls -la ./
+          git-lfs install
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - name: Pre-evaluation script
         run: ${{inputs.pre_evaluation_script}}
       - name: Find builds

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -282,7 +282,7 @@ jobs:
           touch aarch64-evals.json
           if [[ "${{ inputs.eval_target }}" != '' ]]; then
             echo "Evaluating x86_64-linux outputs"
-            (nix eval --json .#"${{ inputs.eval_target }}".x86_64-linux | jq '
+            (nix eval --accept-flake-config --json .#"${{ inputs.eval_target }}".x86_64-linux | jq '
               to_entries | map(
                 {
                   top_attr: "${{ inputs.eval_top_attr}}",
@@ -292,7 +292,7 @@ jobs:
                 }
               )
             ' >> x86_64-evals.json) &
-            (nix eval --json .#"${{ inputs.eval_target }}".aarch64-linux | jq '
+            (nix eval --accept-flake-config --json .#"${{ inputs.eval_target }}".aarch64-linux | jq '
               to_entries | map(
                 {
                   top_attr: "${{ inputs.eval_top_attr}}",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,6 +237,14 @@ jobs:
           rm -rf ./* || true
           rm -rf ./.??* || true
           ls -la ./
+      - uses: nixbuild/nix-quick-install-action@v26
+        with:
+          nix_on_tmpfs: false
+          nix_conf: |
+            experimental-features = nix-command flakes
+            access-tokens = ${{ secrets.access-tokens }}
+            ${{inputs.nix_conf}}
+          nix_version: ${{inputs.nix_version}}
       - uses: actions/checkout@v4
       - name: Pre-evaluation script
         run: ${{inputs.pre_evaluation_script}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,6 +243,7 @@ jobs:
       - name: Find builds
         id: find-builds
         run: |
+          export NIX_CONFIG="access-tokens = ${{ secrets.access-tokens }}"
           set -eo pipefail
           touch flake.json
           flake_json="flake.json"
@@ -331,10 +332,12 @@ jobs:
               ' > $flake_json
           fi
 
-            echo "Jobs to build:"
-            cat $flake_json | jq .
-            jq < "$flake_json" -rc 'map(
-              . as $x | (${{inputs.label_builds}}) as $l | $x + {label: $l})|"builds=\(.)"' >> "$GITHUB_OUTPUT"
+          unset NIX_CONFIG
+
+          echo "Jobs to build:"
+          cat $flake_json | jq .
+          jq < "$flake_json" -rc 'map(
+            . as $x | (${{inputs.label_builds}}) as $l | $x + {label: $l})|"builds=\(.)"' >> "$GITHUB_OUTPUT"
           
   build:
     name: ${{matrix.build.label}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,19 +227,11 @@ jobs:
 
   eval-flake:
     name: "Evaluate flake"
-    runs-on: beefy-runner
+    runs-on: beefy-sausage-16-32-hil-1
     outputs:
       builds: ${{ steps.find-builds.outputs.builds }}
     steps:
       - uses: actions/checkout@v4
-      - uses: nixbuild/nix-quick-install-action@v26
-        with:
-          nix_on_tmpfs: false
-          nix_conf: |
-            experimental-features = nix-command flakes
-            access-tokens = ${{ secrets.access-tokens }}
-            ${{inputs.nix_conf}}
-          nix_version: ${{inputs.nix_version}}
       - name: Pre-evaluation script
         run: ${{inputs.pre_evaluation_script}}
       - name: Find builds

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,14 +237,6 @@ jobs:
           rm -rf ./* || true
           rm -rf ./.??* || true
           ls -la ./
-      - uses: nixbuild/nix-quick-install-action@v26
-        with:
-          nix_on_tmpfs: false
-          nix_conf: |
-            experimental-features = nix-command flakes
-            access-tokens = ${{ secrets.access-tokens }}
-            ${{inputs.nix_conf}}
-          nix_version: ${{inputs.nix_version}}
       - uses: actions/checkout@v4
       - name: Pre-evaluation script
         run: ${{inputs.pre_evaluation_script}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -283,7 +283,7 @@ jobs:
           jq . flake_evals.json
           if [[ "${{ inputs.eval_target }}" != '' ]]; then
             echo "Evaluating x86_64-linux outputs"
-            nix eval --json .#"${{ inputs.eval_target }}".x86_64-linux | jq '
+            time nix eval --json .#"${{ inputs.eval_target }}".x86_64-linux | jq '
               to_entries | map(
                 {
                   top_attr: "${{ inputs.eval_top_attr}}",
@@ -293,7 +293,7 @@ jobs:
                 }
               )
             ' >> flake_evals.json
-            nix eval --json .#"${{ inputs.eval_target }}".aarch64-linux | jq '
+            time nix eval --json .#"${{ inputs.eval_target }}".aarch64-linux | jq '
               to_entries | map(
                 {
                   top_attr: "${{ inputs.eval_top_attr}}",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,7 +227,7 @@ jobs:
 
   eval-flake:
     name: "Evaluate flake"
-    runs-on: beefy-sausage-16-32-hel1-1
+    runs-on: beefy-sausage-16-32-hil-1
     outputs:
       builds: ${{ steps.find-builds.outputs.builds }}
     steps:


### PR DESCRIPTION
- Move to running evaluation jobs on the beefy-sausage runner configured with [unionlabs/github-runner-flake](https://github.com/unionlabs/github-runner-flake).
- Also running evals for both systems in parallel
- New eval times on unionlabs/union
  - build/packages: ~1m35s
  - dev/devShells: ~1m
  - test/checks: 1m20s
- Example run [here](https://github.com/unionlabs/union/actions/runs/7968329820?pr=1356)