### PR TITLE
feat: use basic level auth when calling lfs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -375,6 +375,7 @@ jobs:
       - name: "Build ${{matrix.build.top_attr}}.${{matrix.build.system}}.${{matrix.build.attr}}"
         id: build
         run: |
+          git config lfs.https://github.com/${{ github.repository}}.git/info.access basic
           touch build.json
 
           attempt=0


### PR DESCRIPTION
> lfs.\<url\>.access
> Note: this setting is normally set by LFS itself on receiving a 401 response (authentication required), you don't normally need to set it manually.
> If set to "basic" then credentials will be requested before making batch requests to this url, otherwise a public request will initially be attempted.